### PR TITLE
Move `ember-cli-htmlbars` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-typescript": "^4.2.1"
   },
   "devDependencies": {
@@ -70,6 +69,7 @@
     "ember-auto-import": "^2.3.0",
     "ember-cli": "~4.1.0",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",


### PR DESCRIPTION
As this addon does not ship any .hbs files there is no need to list `ember-cli-htmlbars` in `dependencies`