### PR TITLE
docs: update minimum supported Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "webpack": "^5.66.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
@NullVoxPopuli I may be wrong, but this is V1 addon hence no need for ember-auto-import or embroider.

Also `package.json` has

```json
  "engines": {
    "node": "12.* || 14.* || >= 16"
  }
```

hence technically min Node.js version actually is 12, not 14